### PR TITLE
Save order after changing order state/status

### DIFF
--- a/src/main/php/app/code/community/Afterpay/Afterpay/controllers/PaymentController.php
+++ b/src/main/php/app/code/community/Afterpay/Afterpay/controllers/PaymentController.php
@@ -193,6 +193,7 @@ class Afterpay_Afterpay_PaymentController extends Mage_Core_Controller_Front_Act
             if ($order->isPaymentReview()) {
                 $helper->log($logPrefix . 'Re-checking order payment status: ' . $order->getIncrementId(), Zend_Log::INFO);
                 $payment->registerPaymentReviewAction(Mage_Sales_Model_Order_Payment::REVIEW_ACTION_UPDATE, true);
+                $order->save();
             } else {
                 $helper->log($logPrefix . 'Order status was not re-checked. Order is not in Payment Review state. OrderID=' . $order->getIncrementId(), Zend_Log::NOTICE);
             }

--- a/src/main/php/app/code/community/Afterpay/Afterpay/etc/config.xml
+++ b/src/main/php/app/code/community/Afterpay/Afterpay/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Afterpay_Afterpay>
-            <version>0.12.8</version>
+            <version>0.12.9</version>
         </Afterpay_Afterpay>
     </modules>
     <afterpay>


### PR DESCRIPTION
The order state and status should be changed on the return callback after the
customer has entered all their details and confirmed their afterpay
payment. The registerPaymentReviewAction method sets the order state and
status to processing, but this is not saved in the database. Immediately
after this is done, the sendNewOrderEmail method is called, which loads
the order from the database, resetting the order status back to
pending_payment.

We resolve this issue by saving the order after calling
registerPaymentReviewAction, the same way as it is done in the core
PayPal IPN model.
