### PR TITLE
logic fix: website IDs don't necessarily match store IDs

### DIFF
--- a/src/app/code/community/Afterpay/Afterpay/Model/Observer.php
+++ b/src/app/code/community/Afterpay/Afterpay/Model/Observer.php
@@ -124,7 +124,7 @@ class Afterpay_Afterpay_Model_Observer
                 $website_code = Mage::getSingleton('adminhtml/config_data')->getWebsite();
                 $website = Mage::getModel('core/website')->load($website_code);
             
-                if ($website->getConfig('payment/' . $payment . '/active')) {
+                if (!$website->getConfig('payment/' . $payment . '/active')) {
                     continue;
                 }
 
@@ -136,7 +136,7 @@ class Afterpay_Afterpay_Model_Observer
 
                 $website = Mage::getModel('core/website')->load($website_param);
             
-                if ($website->getConfig('payment/' . $payment . '/active')) {
+                if (!$website->getConfig('payment/' . $payment . '/active')) {
                     continue;
                 }
 

--- a/src/app/code/community/Afterpay/Afterpay/Model/Observer.php
+++ b/src/app/code/community/Afterpay/Afterpay/Model/Observer.php
@@ -122,27 +122,27 @@ class Afterpay_Afterpay_Model_Observer
             {
 
                 $website_code = Mage::getSingleton('adminhtml/config_data')->getWebsite();
-                $website_id = Mage::getModel('core/website')->load($website_code)->getId();
+                $website = Mage::getModel('core/website')->load($website_code);
             
-                if (!Mage::getStoreConfigFlag('payment/' . $payment . '/active', $website_id)) {
+                if ($website->getConfig('payment/' . $payment . '/active')) {
                     continue;
                 }
 
-                $overrides = array('website_id' => $website_id);
+                $overrides = array('website_id' => $website->getId());
                 $level = 'websites';
-                $target_id = $website_id;
+                $target_id = $website->getId();
             }
             else if( !empty( $website_param ) ) {
 
-                $website_id = $website_param;
+                $website = Mage::getModel('core/website')->load($website_param);
             
-                if (!Mage::getStoreConfigFlag('payment/' . $payment . '/active', $website_id)) {
+                if ($website->getConfig('payment/' . $payment . '/active')) {
                     continue;
                 }
 
-                $overrides = array('website_id' => $website_id);
+                $overrides = array('website_id' => $website->getId());
                 $level = 'websites';
-                $target_id = $website_id;
+                $target_id = $website->getId();
             }
             else // default level
             {

--- a/src/app/code/community/Afterpay/Afterpay/Model/System/Config/Source/ApiMode.php
+++ b/src/app/code/community/Afterpay/Afterpay/Model/System/Config/Source/ApiMode.php
@@ -53,26 +53,26 @@ class Afterpay_Afterpay_Model_System_Config_Source_ApiMode
      */
     protected static function _getConfigSettings()
     {
-        if(Mage::app()->getStore()->isAdmin()) {
-            $websiteCode = Mage::app()->getRequest()->getParam('website');
+        if (!Mage::app()->getStore()->isAdmin()) {
+            $store = Mage::app()->getStore();
+
+        } else {
+            $websiteCode    = Mage::app()->getRequest()->getParam('website');
+            $orderId        = Mage::app()->getRequest()->getParam('order_id');
             
             if ($websiteCode) {
-                $website = Mage::getModel('core/website')->load($websiteCode);
-                $websiteId = $website->getId();
-            } else {
-                $order_id = Mage::app()->getRequest()->getParam('order_id');
+                $website    = Mage::getModel('core/website')->load($websiteCode);
+                $store      = $website->getDefaultStore();
 
-                if($order_id) {
-                    $websiteId = Mage::getModel('core/store')->load(Mage::getModel('sales/order')->load($order_id)->getStoreId())->getWebsiteId();
-                } else {
-                    $websiteId = 0;
-                }
+            } else if ($orderId) {
+                $store      = Mage::getModel('sales/order')->load($orderId)->getStore();
+
+            } else {
+                $store      = Mage::app()->getDefaultStoreView();
             }
-        } else {
-            $websiteId = '';
         }
 
-        if(Mage::app()->getStore($websiteId)->getCurrentCurrencyCode() == 'USD') {
+        if ($store->getCurrentCurrencyCode() == 'USD') {
             $api = 'api_us_url';
             $web = 'web_us_url';
         } else {


### PR DESCRIPTION
Since it's possible to have multiple store views per website, it's incorrect to assume that a website ID can be used to get a store view within that website. In my case the store view that matched one of my website ID had been deleted, so this caused the Payment Methods admin page to be replaced with a 404 error for that website scope.