### PR TITLE
Using website object, instead of the store.

### DIFF
--- a/src/app/code/community/Afterpay/Afterpay/Model/System/Config/Source/ApiMode.php
+++ b/src/app/code/community/Afterpay/Afterpay/Model/System/Config/Source/ApiMode.php
@@ -69,7 +69,8 @@ class Afterpay_Afterpay_Model_System_Config_Source_ApiMode
                 }
             }
         } else {
-            $websiteId = '';
+            // use current store website outside of the admin section
+            $websiteId = Mage::app()->getStore()->getWebsite()->getId();
         }
 
         $api = 'api_url';

--- a/src/app/code/community/Afterpay/Afterpay/Model/System/Config/Source/ApiMode.php
+++ b/src/app/code/community/Afterpay/Afterpay/Model/System/Config/Source/ApiMode.php
@@ -72,12 +72,15 @@ class Afterpay_Afterpay_Model_System_Config_Source_ApiMode
             $websiteId = '';
         }
 
-        if(Mage::app()->getStore($websiteId)->getCurrentCurrencyCode() == 'USD') {
-            $api = 'api_us_url';
-            $web = 'web_us_url';
-        } else {
-            $api = 'api_url';
-            $web = 'web_url';
+        $api = 'api_url';
+        $web = 'web_url';
+
+        $website = Mage::app()->getWebsite($websiteId);
+        if ($website) {
+            if($website->getCurrentCurrencyCode() == 'USD') {
+                $api = 'api_us_url';
+                $web = 'web_us_url';
+            }
         }
 
         $options = array();


### PR DESCRIPTION
In Magento the Store and Website models are different.

If the website currency code is USD, then we can load the American URLs. This may be better implemented by setting the URL's in system config so even custom URLs could be handled.

To replicate the issue you need to have a multistore setup where one store's ID is different to the website ID.