### PR TITLE
Magestore_onestep call original function if not Afterpay

### DIFF
--- a/src/js/Afterpay/checkout/magestore_onestep.js
+++ b/src/js/Afterpay/checkout/magestore_onestep.js
@@ -121,6 +121,12 @@
                         }
                     }
                 );
+            } else {
+                /**
+                 * Call original function
+                 */
+                original.apply(this, arguments);
+            }
             }
         };
     }


### PR DESCRIPTION
Without this, Paypal redirect (and potentially other payment methods) don't happen.