### PR TITLE
Make default order status configurable

### DIFF
--- a/src/app/code/community/Afterpay/Afterpay/etc/system.xml
+++ b/src/app/code/community/Afterpay/Afterpay/etc/system.xml
@@ -27,6 +27,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </title>
+                        <order_status translate="label comment">
+                            <label>New Order Status</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_order_status_processing</source_model>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </order_status>
                         <api_mode translate="label">
                             <label>API Mode</label>
                             <frontend_type>select</frontend_type>


### PR DESCRIPTION
In most Magento payment method extensions you can set the default order status for a new order in the configuration panel. The order status value already exists in the afterpay extension, however it's not exposed to the configuration panel.